### PR TITLE
CUDD dependency build improvements and fixes

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,7 @@ if is_unix()
     cd("cudd-3.0.0/")
 
     run(`autoreconf -fi`)
-    run(`./configure --enable-silent-rules --enable-shared --enable-obj --with-system-qsort`)
+    run(`./configure --enable-silent-rules --enable-shared --enable-obj`)
     run(`make -j$(Sys.CPU_CORES) check`)
 
     # rename the shared library if it's ended with dylib...

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ if is_unix()
 
     run(`autoreconf -fi`)
     run(`./configure --enable-silent-rules --enable-shared --enable-obj --with-system-qsort`)
-    run(`make -j$Sys.CPU_CORES check`)
+    run(`make -j$(Sys.CPU_CORES) check`)
 
     # rename the shared library if it's ended with dylib...
     cd("cudd/.libs")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,6 +4,7 @@ if is_unix()
     rm("cudd-3.0.0.tar.gz")
     cd("cudd-3.0.0/")
 
+    run(`./autoreconf -fi`)
     run(`./configure --enable-silent-rules --enable-shared --enable-obj --with-system-qsort`)
     run(`make -j$Sys.CPU_CORES check`)
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,7 +4,7 @@ if is_unix()
     rm("cudd-3.0.0.tar.gz")
     cd("cudd-3.0.0/")
 
-    run(`./autoreconf -fi`)
+    run(`autoreconf -fi`)
     run(`./configure --enable-silent-rules --enable-shared --enable-obj --with-system-qsort`)
     run(`make -j$Sys.CPU_CORES check`)
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,11 +1,11 @@
 if is_unix()
-    download("ftp://vlsi.colorado.edu/pub/cudd-3.0.0.tar.gz", "cudd-3.0.0.tar.gz")
+    download("https://github.com/kozross/cudd/archive/v3.0.0.tar.gz", "cudd-3.0.0.tar.gz")
     run(`tar -zxvf cudd-3.0.0.tar.gz`)
     rm("cudd-3.0.0.tar.gz")
     cd("cudd-3.0.0/")
 
-    run(`./configure --enable-silent-rules --enable-shared --enable-obj`)
-    run(`make -j4 check`)
+    run(`./configure --enable-silent-rules --enable-shared --enable-obj --with-system-qsort`)
+    run(`make -j$Sys.CPU_CORES check`)
 
     # rename the shared library if it's ended with dylib...
     cd("cudd/.libs")


### PR DESCRIPTION
This is mostly designed to address #1 - I've replaced the source link with the one I suggested. I've also added two quality-of-life improvements:

* Instead of forcing a four-core build, I've used ``Sys.CPU_CORES`` to determine this, so that people on machines with more or fewer get a more system-appropriate amount of parallelism
* <s>I've passed the (under-documented) parameter to configure that uses the system's ``qsort`` instead of the one CUDD provides (as it'll likely be more efficient)</s>Turns out that this breaks multiple tests. I'll report an upstream bug.