### PR TITLE
Fix incorrect spelling of 'initialize'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ C library to manipulate Algebraic Decision Diagrams (ADDs).
 Basic usage:
 ```julia
 >>> using CUDD
->>> manager = initilize_cudd()
+>>> manager = initialize_cudd()
 >>> x1 = add_var(manager)
 >>> ref(x1)
 >>> x2 = add_var(manager)

--- a/docs/example_usage.ipynb
+++ b/docs/example_usage.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "manager = initilize_cudd() # creates the DD manager that manages the nodes and operations"
+    "manager = initialize_cudd() # creates the DD manager that manages the nodes and operations"
    ]
   },
   {
@@ -255,7 +255,7 @@
     }
    ],
    "source": [
-    "manager2 = initilize_cudd()"
+    "manager2 = initialize_cudd()"
    ]
   },
   {

--- a/src/ADD.jl
+++ b/src/ADD.jl
@@ -1,6 +1,6 @@
 export Manager, Node
 export CUDD_UNIQUE_SLOTS, CUDD_CACHE_SLOTS
-export initilize_cudd
+export initialize_cudd
 export add_var, add_ith_var, add_level_var, add_const, add_constraint
 export ref, deref, recursive_deref
 export add_constraint, add_restrict, evaluate
@@ -19,7 +19,7 @@ end
 const CUDD_UNIQUE_SLOTS = 256
 const CUDD_CACHE_SLOTS  = 262144
 
-function initilize_cudd()
+function initialize_cudd()
     dd_manager = ccall((:Cudd_Init, _LIB_CUDD),
         Ptr{Manager}, (Cuint, Cuint, Cuint, Cuint, Csize_t), 0,0,CUDD_UNIQUE_SLOTS,CUDD_CACHE_SLOTS,0) # default in CUDD
     if dd_manager == C_NULL # Could not allocate memory

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 @testset "addind vars" begin
     for i = 1:10
-        manager = initilize_cudd()
+        manager = initialize_cudd()
         rnd = rand(1:100)
         for i = 1:rnd
             add_var(manager)
@@ -12,13 +12,13 @@ using Base.Test
     end
 
     for i = 1:10
-        manager = initilize_cudd()
+        manager = initialize_cudd()
         rnd = rand(i*10:i*10+9)
         indexed_var = add_ith_var(manager, rnd)
         @test read_index(indexed_var) == rnd
     end
 
-    manager = initilize_cudd()
+    manager = initialize_cudd()
     for i = 1:10
         new_nonconst = add_var(manager)
         @test is_nonconst(new_nonconst) == 1
@@ -32,7 +32,7 @@ using Base.Test
 end
 
 @testset "outputting files" begin
-    manager = initilize_cudd()
+    manager = initialize_cudd()
     g = add_var(manager)
     @test output_dot(manager, g, "test.dot") == 1
     rm("test.dot")
@@ -41,7 +41,7 @@ end
 end
 
 @testset "applying constant functions" begin
-    manager = initilize_cudd()
+    manager = initialize_cudd()
     x1, x2 = rand(1:50), rand(51:100)
     f = add_const(manager, x1)
     ref(f)
@@ -74,7 +74,7 @@ end
 end
 
 @testset "addition testing" begin
-    manager = initilize_cudd()
+    manager = initialize_cudd()
     f = add_ith_var(manager, 0)
     ref(f)
     for i = 1:100
@@ -112,7 +112,7 @@ end
 end
 
 @testset "multiplication testing" begin
-    manager = initilize_cudd()
+    manager = initialize_cudd()
     f = add_ith_var(manager, 1)
     ref(f)
     for i = 2:101


### PR DESCRIPTION
Spelling errors just look unsightly, and this one is very glaring because it's also in the docs.