### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Basic usage:
 >>> x2 = add_var(manager)
 >>> ref(x2)
 >>> f = add_apply(manager, add_plus_c, x1, x2)
->>> get_value(evaluate(manager, f, [1, 1]))
-2
+>>> get_value(evaluate(manager, f, Cint[1, 1]))
+2.0
 ```
 
 For further examples, see the Julia notebook in the ``docs`` folder.


### PR DESCRIPTION
With the README example, on my 64-bit machine, I get
```julia
julia> get_value(evaluate(manager, f, [1, 1]))
ERROR: MethodError: no method matching evaluate(::Ptr{Manager}, ::Ptr{Node}, ::Array{Int64,1})
Closest candidates are:
  evaluate(::Ptr{Manager}, ::Ptr{Node}, ::Array{Int32,N} where N) at /home/blegat/.julia/dev/CUDD/src/ADD.jl:88
Stacktrace:
 [1] top-level scope at REPL[12]:1
```