### PR TITLE
Convert ptr to `UInt` instead of `Int` in missing C macros

### DIFF
--- a/src/CUDD.jl
+++ b/src/CUDD.jl
@@ -10,13 +10,13 @@ include(joinpath(@__DIR__, "gen", "libcudd_api.jl"))
 # Missing C macros omitted by Clang.jl
 
 Cudd_Not(node) =
-    convert(Ptr{Nothing}, xor(convert(Int,node), 1))
+    convert(Ptr{Nothing}, xor(convert(UInt,node), 1))
 
 Cudd_IsComplement(node) =
-    isone(convert(Int,node) & 1)
+    isone(convert(UInt,node) & 1)
 
 Cudd_Regular(node) = 
-    convert(Ptr{Nothing}, convert(Int,node) & ~1)
+    convert(Ptr{Nothing}, convert(UInt,node) & ~1)
 
 # export everything
 foreach(names(@__MODULE__, all=true)) do s


### PR DESCRIPTION
Converting a `Ptr` to `Int` errors if the top bit is 1.

Without this change, I ran into errors like the following when calling `Cudd_Regular`, `Cudd_IsComplement`, and `Cudd_Not`:
```
InexactError: check_top_bit(Int64, 18446744073709547520)
```

